### PR TITLE
Feature/edit-account-picture

### DIFF
--- a/lib/generated/intl/messages_pt.dart
+++ b/lib/generated/intl/messages_pt.dart
@@ -65,6 +65,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "textAppBarSignUp": MessageLookupByLibrary.simpleMessage("Cadastro"),
         "textAtLeast8Characteres": MessageLookupByLibrary.simpleMessage(
             "- Sua senha deve ter mais de 8 caracteres"),
+        "textAvatarSuccessUpated": MessageLookupByLibrary.simpleMessage(
+            "Avatar alterado com sucesso!"),
         "textBackToLocation":
             MessageLookupByLibrary.simpleMessage("Voltar ao local"),
         "textBestRates":
@@ -170,6 +172,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "textExamplePronouns": MessageLookupByLibrary.simpleMessage(
             "Exemplo: Ela/Dela, Elu/Delu, Ela/Elu"),
         "textExcited": MessageLookupByLibrary.simpleMessage("Alegre"),
+        "textFailedToUpdateAvatar": MessageLookupByLibrary.simpleMessage(
+            "Não foi possível alterar o avatar!"),
         "textFeatureAvailableSoon": MessageLookupByLibrary.simpleMessage(
             "Funcionalidade disponível em breve"),
         "textFinish": MessageLookupByLibrary.simpleMessage("Finalizar"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1430,6 +1430,26 @@ class S {
     );
   }
 
+  /// `Avatar alterado com sucesso!`
+  String get textAvatarSuccessUpated {
+    return Intl.message(
+      'Avatar alterado com sucesso!',
+      name: 'textAvatarSuccessUpated',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Não foi possível alterar o avatar!`
+  String get textFailedToUpdateAvatar {
+    return Intl.message(
+      'Não foi possível alterar o avatar!',
+      name: 'textFailedToUpdateAvatar',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Sucesso!`
   String get textSafeDialogTypeSucces {
     return Intl.message(

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -149,6 +149,8 @@
     "textMostPeopleAlertPlace":"Algumas pessoas\n reportaram problemas\n associados a esse local para\n comunidade LGBTQIA+",
     "textMostPeopleDangerPlace":"Local não recomendado.\n A maioria das pessoas não\n considera esse local seguro\n para comunidade LGBTQIA+",
 
+    "textAvatarSuccessUpated": "Avatar alterado com sucesso!",
+    "textFailedToUpdateAvatar": "Não foi possível alterar o avatar!",
 
     "textSafeDialogTypeSucces":"Sucesso!",
     "textSafeDialogTypeAlert":"Atenção!",

--- a/lib/src/app/modules/auth/register/presenter/bloc/register_bloc.dart
+++ b/lib/src/app/modules/auth/register/presenter/bloc/register_bloc.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:is_it_safe_app/generated/l10n.dart';
-import 'package:is_it_safe_app/src/core/constants/assets_constants.dart';
 import 'package:is_it_safe_app/src/core/constants/string_constants.dart';
 import 'package:is_it_safe_app/src/core/interfaces/safe_bloc.dart';
 import 'package:is_it_safe_app/src/core/util/safe_log_util.dart';
@@ -17,16 +15,18 @@ import 'package:is_it_safe_app/src/domain/use_case/get_sexual_orientation_use_ca
 import 'package:is_it_safe_app/src/components/config/safe_event.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 
+import '../../../../../../components/widgets/safe_profile_picture/bloc/safe_profile_picture_bloc.dart';
+
 class RegisterBloc extends SafeBloC {
   final DoRegisterUseCase doRegisterUseCase;
   final GetSexualOrientationsUseCase getSexualOrientationsUseCase;
   final GetGendersUseCase getGendersUseCase;
+  final SafeProfilePictureBloC profilePictureController;
 
   late final MaskTextInputFormatter birthdayInputMask;
   late final MaskTextInputFormatter phoneInputMask;
 
   late StreamController<bool> registerButtonController;
-  late StreamController<String> profilePictureController;
   late StreamController<SafeEvent<List<GenderEntity>>> gendersController;
   late StreamController<SafeEvent<List<SexualOrientationEntity>>>
       sexualOrientationsController;
@@ -43,15 +43,14 @@ class RegisterBloc extends SafeBloC {
   late TextEditingController sexualOrientationController;
 
   bool isTermsAndConditionsChecked = false;
-  List<String> listProfilePicturePaths = [];
   List<GenderEntity> listGenders = [];
   List<SexualOrientationEntity> listSexualOrientations = [];
-  String selectedProfilePhoto = StringConstants.empty;
 
   RegisterBloc({
     required this.doRegisterUseCase,
     required this.getGendersUseCase,
     required this.getSexualOrientationsUseCase,
+    required this.profilePictureController,
   }) {
     init();
   }
@@ -62,7 +61,6 @@ class RegisterBloc extends SafeBloC {
     phoneInputMask = MaskTextInputFormatter(mask: StringConstants.phoneMask);
 
     registerButtonController = StreamController.broadcast();
-    profilePictureController = StreamController.broadcast();
     gendersController = StreamController.broadcast();
     sexualOrientationsController = StreamController.broadcast();
     doRegisterController = StreamController.broadcast();
@@ -86,24 +84,6 @@ class RegisterBloc extends SafeBloC {
         confirmPasswordController.text.isNotEmpty &&
         isTermsAndConditionsChecked);
     registerButtonController.sink.add(isRegisterButtonEnabled);
-  }
-
-  Future<void> getProfilePicturePathsList(BuildContext context) async {
-    listProfilePicturePaths.clear();
-    final assetManifestJson =
-        await DefaultAssetBundle.of(context).loadString('AssetManifest.json');
-    final List<String> profilePicturePaths = json
-        .decode(assetManifestJson)
-        .keys
-        .where((String key) =>
-            key.startsWith(AssetConstants.general.profilePictures))
-        .toList();
-    listProfilePicturePaths.addAll(profilePicturePaths);
-  }
-
-  void setProfitePicture(String path) {
-    selectedProfilePhoto = path;
-    profilePictureController.sink.add(path);
   }
 
   Future<void> getGenders() async {
@@ -150,7 +130,7 @@ class RegisterBloc extends SafeBloC {
         password: passwordController.text,
         profilePhoto: isAdvanceButton == true
             ? StringConstants.empty
-            : selectedProfilePhoto,
+            : profilePictureController.selectedProfilePhoto,
         gender: isAdvanceButton == true ? "${7}" : genderController.text,
         sexualOrientation:
             isAdvanceButton == true ? "${2}" : sexualOrientationController.text,

--- a/lib/src/app/modules/auth/register/presenter/widgets/choose_profile_avatar.dart
+++ b/lib/src/app/modules/auth/register/presenter/widgets/choose_profile_avatar.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:is_it_safe_app/src/app/modules/auth/register/presenter/bloc/register_bloc.dart';
+import 'package:is_it_safe_app/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart';
 
 import '../../../../../../../generated/l10n.dart';
 import '../../../../../../components/style/text/text_styles.dart';
 import '../../../../../../components/widgets/safe_profile_avatar.dart';
 import '../../../../../../core/constants/string_constants.dart';
-import '../pages/register_profile_picture_page.dart';
 
 class ChooseProfileAvatar extends StatelessWidget {
   final RegisterBloc controller;
@@ -19,11 +19,13 @@ class ChooseProfileAvatar extends StatelessWidget {
       child: Column(
         children: [
           StreamBuilder<String>(
-            stream: controller.profilePictureController.stream,
+            stream: controller
+                .profilePictureController.profilePictureController.stream,
             builder: (context, snapshot) {
               if (snapshot.hasData) {
                 return SafeProfileAvatar(
-                  image: controller.selectedProfilePhoto,
+                  image:
+                      controller.profilePictureController.selectedProfilePhoto,
                   onTap: _goToProfilePicturePage,
                 );
               } else {
@@ -51,10 +53,10 @@ class ChooseProfileAvatar extends StatelessWidget {
 
   void _goToProfilePicturePage() {
     Modular.to
-        .pushNamed(StringConstants.dot + RegisterProfilePicturePage.route)
+        .pushNamed(StringConstants.dot + SafeProfilePicturePage.route)
         .then((value) {
       if (value != null) {
-        controller.setProfitePicture(value.toString());
+        controller.profilePictureController.setProfitePicture(value.toString());
       }
     });
   }

--- a/lib/src/app/modules/auth/register/register_module.dart
+++ b/lib/src/app/modules/auth/register/register_module.dart
@@ -2,7 +2,8 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:is_it_safe_app/src/app/modules/auth/register/presenter/bloc/register_bloc.dart';
 import 'package:is_it_safe_app/src/app/modules/auth/register/presenter/pages/register_page.dart';
 import 'package:is_it_safe_app/src/app/modules/auth/register/presenter/pages/register_profile_page.dart';
-import 'package:is_it_safe_app/src/app/modules/auth/register/presenter/pages/register_profile_picture_page.dart';
+import 'package:is_it_safe_app/src/components/widgets/safe_profile_picture/bloc/safe_profile_picture_bloc.dart';
+import 'package:is_it_safe_app/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart';
 import 'package:is_it_safe_app/src/domain/use_case/do_register_use_case.dart';
 import 'package:is_it_safe_app/src/domain/use_case/get_genders_use_case.dart';
 import 'package:is_it_safe_app/src/domain/use_case/get_sexual_orientation_use_case.dart';
@@ -17,10 +18,12 @@ class RegisterModule extends Module {
     Bind.lazySingleton((i) => GetSexualOrientationsUseCase()),
     Bind.lazySingleton((i) => GetGendersUseCase()),
     Bind.lazySingleton((i) => DoRegisterUseCase()),
+    Bind.lazySingleton((i) => SafeProfilePictureBloC()),
     Bind.lazySingleton((i) => RegisterBloc(
           doRegisterUseCase: i.get<DoRegisterUseCase>(),
           getGendersUseCase: i.get<GetGendersUseCase>(),
           getSexualOrientationsUseCase: i.get<GetSexualOrientationsUseCase>(),
+          profilePictureController: i.get<SafeProfilePictureBloC>(),
         )),
   ];
 
@@ -35,8 +38,8 @@ class RegisterModule extends Module {
       child: (context, args) => const RegisterProfilePage(),
     ),
     ChildRoute(
-      RegisterProfilePicturePage.route,
-      child: (context, args) => const RegisterProfilePicturePage(),
+      SafeProfilePicturePage.route,
+      child: (context, args) => const SafeProfilePicturePage(),
     ),
   ];
 }

--- a/lib/src/app/modules/configuration/account/account_module.dart
+++ b/lib/src/app/modules/configuration/account/account_module.dart
@@ -1,11 +1,15 @@
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/presenter/bloc/account_bloc.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/presenter/pages/account_page.dart';
+import 'package:is_it_safe_app/src/components/widgets/safe_profile_picture/bloc/safe_profile_picture_bloc.dart';
+import 'package:is_it_safe_app/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart';
 import 'package:is_it_safe_app/src/domain/use_case/get_user_use_case.dart';
 import 'package:is_it_safe_app/src/domain/use_case/save_user_login_use_case.dart';
 import 'package:is_it_safe_app/src/service/api/modules/auth/auth_service.dart';
 import 'package:is_it_safe_app/src/service/api/modules/profile/profile_service.dart';
 import 'package:is_it_safe_app/src/service/shared_preferences/shared_preferences_service.dart';
+
+import '../../../../domain/use_case/update_user_use_case.dart';
 
 class AccountModule extends Module {
   @override
@@ -14,9 +18,13 @@ class AccountModule extends Module {
     Bind.lazySingleton((i) => ProfileService(i.get<AuthService>())),
     Bind.lazySingleton((i) => SaveUserLoginUseCase()),
     Bind.lazySingleton((i) => GetUserUseCase()),
+    Bind.lazySingleton((i) => UpdateUserUseCase()),
+    Bind.lazySingleton((i) => SafeProfilePictureBloC()),
     Bind.lazySingleton((i) => AccountBloc(
           getUserUseCase: i.get<GetUserUseCase>(),
+          updateUserUseCase: i.get<UpdateUserUseCase>(),
           saveUserLoginUseCase: i.get<SaveUserLoginUseCase>(),
+          safeProfilePictureBloc: i.get<SafeProfilePictureBloC>(),
         )),
   ];
 
@@ -25,6 +33,10 @@ class AccountModule extends Module {
     ChildRoute(
       Modular.initialRoute,
       child: (context, args) => const AccountPage(),
+    ),
+    ChildRoute(
+      SafeProfilePicturePage.route,
+      child: (context, args) => const SafeProfilePicturePage(),
     ),
   ];
 }

--- a/lib/src/app/modules/configuration/account/presenter/bloc/account_bloc.dart
+++ b/lib/src/app/modules/configuration/account/presenter/bloc/account_bloc.dart
@@ -2,22 +2,29 @@ import 'dart:async';
 
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:is_it_safe_app/src/app/modules/auth/login/presenter/pages/login_page.dart';
+import 'package:is_it_safe_app/src/components/widgets/safe_profile_picture/bloc/safe_profile_picture_bloc.dart';
 import 'package:is_it_safe_app/src/domain/use_case/get_user_use_case.dart';
 import 'package:is_it_safe_app/src/core/interfaces/safe_bloc.dart';
 import 'package:is_it_safe_app/src/domain/entity/user_entity.dart';
 import 'package:is_it_safe_app/src/domain/use_case/save_user_login_use_case.dart';
 import 'package:is_it_safe_app/src/components/config/safe_event.dart';
+import 'package:is_it_safe_app/src/domain/use_case/update_user_use_case.dart';
 import 'package:is_it_safe_app/src/service/api/error/error_exceptions.dart';
+import 'package:is_it_safe_app/src/service/api/modules/profile/request/resquest_update_user.dart';
 
 class AccountBloc extends SafeBloC {
   final GetUserUseCase getUserUseCase;
+  final UpdateUserUseCase updateUserUseCase;
   final SaveUserLoginUseCase saveUserLoginUseCase;
+  final SafeProfilePictureBloC safeProfilePictureBloc;
 
   late StreamController<SafeEvent<UserEntity>> userController;
 
   AccountBloc({
     required this.getUserUseCase,
+    required this.updateUserUseCase,
     required this.saveUserLoginUseCase,
+    required this.safeProfilePictureBloc,
   }) {
     init();
   }
@@ -32,6 +39,18 @@ class AccountBloc extends SafeBloC {
     try {
       userController.sink.add(SafeEvent.load());
       final response = await getUserUseCase.call();
+      userController.sink.add(SafeEvent.done(response));
+    } on Exception catch (e) {
+      //TODO colocar tratamento de erro de autenticação em todas as requisições
+      userController.addError(e.toString());
+      if (e is UnauthorizedException) await doLogout();
+    }
+  }
+
+  Future<void> updateUser(RequestUpdateUser request) async {
+    try {
+      userController.sink.add(SafeEvent.load());
+      final response = await updateUserUseCase.call(request);
       userController.sink.add(SafeEvent.done(response));
     } on Exception catch (e) {
       //TODO colocar tratamento de erro de autenticação em todas as requisições

--- a/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
+++ b/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
@@ -101,6 +101,18 @@ class _AccountPageState extends ModularState<AccountPage, AccountBloc> {
                           controller.safeProfilePictureBloc
                               .setProfitePicture(value.toString());
                         });
+                        SafeSnackBar(
+                                type: SnackBarType.success,
+                                message: S.current.textAvatarSuccessUpated)
+                            .show(context);
+
+                        controller.userController.stream.handleError((x) {
+                          SafeSnackBar(
+                                  type: SnackBarType.error,
+                                  message: S.current.textFailedToUpdateAvatar)
+                              .show(context);
+                        });
+
                         await controller
                             .updateUser(RequestUpdateUser(
                           id: user!.id,

--- a/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
+++ b/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
@@ -13,6 +13,9 @@ import 'package:is_it_safe_app/src/components/widgets/safe_profile_header.dart';
 import 'package:is_it_safe_app/src/components/widgets/safe_snack_bar.dart';
 import 'package:is_it_safe_app/src/domain/entity/user_entity.dart';
 import 'package:is_it_safe_app/src/components/config/safe_event.dart';
+import 'package:is_it_safe_app/src/service/api/modules/profile/request/resquest_update_user.dart';
+import '../../../../../../components/widgets/safe_profile_picture/safe_profile_picture_page.dart';
+import '../../../../../../core/constants/string_constants.dart';
 import 'confirm_password.dart';
 
 class AccountPage extends StatefulWidget {
@@ -82,19 +85,30 @@ class _AccountPageState extends ModularState<AccountPage, AccountBloc> {
             case Status.done:
               //TODO salvar o usuário no shared preferences
               return SafeProfileHeader(
-                nickname: user?.nickname,
-                //TODO descomentar a foto
-                //photo: user?.profilePhoto,
-                pronoun: user?.pronoun,
-                gender: user?.gender,
-                sexualOrientation: user?.orientation,
-                isEditabled: true,
-                //TODO substituir por: navegação para tela de editar profile picture
-                onPhotoTap: () => SafeSnackBar(
-                  message: S.current.textFeatureAvailableSoon,
-                  type: SnackBarType.info,
-                ).show(context),
-              );
+                  nickname: user?.nickname,
+                  //TODO descomentar a foto
+                  photo: controller.safeProfilePictureBloc.selectedProfilePhoto,
+                  pronoun: user?.pronoun,
+                  gender: user?.gender,
+                  sexualOrientation: user?.orientation,
+                  isEditabled: true,
+                  //TODO substituir por: navegação para tela de editar profile picture
+                  onPhotoTap: () {
+                    Modular.to
+                        .pushNamed(
+                            StringConstants.dot + SafeProfilePicturePage.route)
+                        .then((value) async {
+                      if (value != null) {
+                        controller.safeProfilePictureBloc
+                            .setProfitePicture(value.toString());
+                        setState(() {});
+                        await controller.updateUser(RequestUpdateUser(
+                          id: user!.id,
+                          profilePhoto: value.toString(),
+                        ));
+                      }
+                    });
+                  });
             default:
               return const SafeProfileHeader();
           }

--- a/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
+++ b/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
@@ -86,26 +86,29 @@ class _AccountPageState extends ModularState<AccountPage, AccountBloc> {
               //TODO salvar o usuário no shared preferences
               return SafeProfileHeader(
                   nickname: user?.nickname,
-                  //TODO descomentar a foto
-                  photo: controller.safeProfilePictureBloc.selectedProfilePhoto,
+                  photo: user?.profilePhoto,
                   pronoun: user?.pronoun,
                   gender: user?.gender,
                   sexualOrientation: user?.orientation,
                   isEditabled: true,
-                  //TODO substituir por: navegação para tela de editar profile picture
                   onPhotoTap: () {
                     Modular.to
                         .pushNamed(
                             StringConstants.dot + SafeProfilePicturePage.route)
                         .then((value) async {
                       if (value != null) {
-                        controller.safeProfilePictureBloc
-                            .setProfitePicture(value.toString());
-                        setState(() {});
-                        await controller.updateUser(RequestUpdateUser(
+                        setState(() {
+                          controller.safeProfilePictureBloc
+                              .setProfitePicture(value.toString());
+                        });
+                        await controller
+                            .updateUser(RequestUpdateUser(
                           id: user!.id,
                           profilePhoto: value.toString(),
-                        ));
+                        ))
+                            .then((_) async {
+                          await controller.getUser();
+                        });
                       }
                     });
                   });
@@ -146,32 +149,32 @@ class _AccountPageState extends ModularState<AccountPage, AccountBloc> {
                     const SizedBox(height: 20),
                     AccountInfoTile(
                       title: S.current.textName,
-                      value: user?.name,
+                      value: user!.name,
                     ),
                     const SizedBox(height: 20),
                     AccountInfoTile(
                       title: S.current.textUsername,
-                      value: user?.nickname,
+                      value: user.nickname,
                     ),
                     const SizedBox(height: 20),
                     AccountInfoTile(
                       title: S.current.textPronouns,
-                      value: user?.pronoun,
+                      value: user.pronoun,
                     ),
                     const SizedBox(height: 20),
                     AccountInfoTile(
                       title: S.current.textDateOfBirth,
-                      value: user?.birthDate,
+                      value: user.birthDate,
                     ),
                     const SizedBox(height: 20),
                     AccountInfoTile(
                       title: S.current.textSexualOrientation,
-                      value: user?.orientation,
+                      value: user.orientation,
                     ),
                     const SizedBox(height: 20),
                     AccountInfoTile(
                       title: S.current.textGender,
-                      value: user?.gender,
+                      value: user.gender,
                     ),
                   ],
                 ),

--- a/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
+++ b/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
@@ -18,6 +18,7 @@ import 'package:is_it_safe_app/src/service/api/modules/profile/request/resquest_
 import '../../../../../../components/widgets/safe_profile_picture/safe_profile_picture_page.dart';
 import '../../../../../../core/constants/string_constants.dart';
 import '../../../configuration_module.dart';
+import 'confirm_password.dart';
 
 class AccountPage extends StatefulWidget {
   static const route = '/account/';

--- a/lib/src/components/widgets/safe_profile_picture/bloc/safe_profile_picture_bloc.dart
+++ b/lib/src/components/widgets/safe_profile_picture/bloc/safe_profile_picture_bloc.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:is_it_safe_app/src/core/interfaces/safe_bloc.dart';
+
+import '../../../../core/constants/assets_constants.dart';
+import '../../../../core/constants/string_constants.dart';
+
+class SafeProfilePictureBloC extends SafeBloC {
+  List<String> listProfilePicturePaths = [];
+  String selectedProfilePhoto = StringConstants.empty;
+  late StreamController<String> profilePictureController;
+
+  SafeProfilePictureBloC() {
+    init();
+  }
+
+  @override
+  Future<void> init() async {
+    profilePictureController = StreamController.broadcast();
+  }
+
+  Future<void> getProfilePicturePathsList(BuildContext context) async {
+    listProfilePicturePaths.clear();
+    final assetManifestJson =
+        await DefaultAssetBundle.of(context).loadString('AssetManifest.json');
+    final List<String> profilePicturePaths = json
+        .decode(assetManifestJson)
+        .keys
+        .where((String key) =>
+            key.startsWith(AssetConstants.general.profilePictures))
+        .toList();
+    listProfilePicturePaths.addAll(profilePicturePaths);
+  }
+
+  void setProfitePicture(String path) {
+    selectedProfilePhoto = path;
+    profilePictureController.sink.add(path);
+  }
+
+  @override
+  Future<void> dispose() async {
+    profilePictureController.close();
+  }
+}

--- a/lib/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart
+++ b/lib/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart
@@ -17,8 +17,8 @@ class SafeProfilePicturePage extends StatefulWidget {
   State<SafeProfilePicturePage> createState() => _SafeProfilePicturePageState();
 }
 
-class _SafeProfilePicturePageState
-    extends ModularState<SafeProfilePicturePage, SafeProfilePictureBloC> {
+class _SafeProfilePicturePageState extends State<SafeProfilePicturePage> {
+  final controller = Modular.get<SafeProfilePictureBloC>();
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   late String userAvatarPath;
 

--- a/lib/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart
+++ b/lib/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart
@@ -17,9 +17,8 @@ class SafeProfilePicturePage extends StatefulWidget {
   State<SafeProfilePicturePage> createState() => _SafeProfilePicturePageState();
 }
 
-class _SafeProfilePicturePageState extends State<SafeProfilePicturePage> {
-  final controller = Modular.get<SafeProfilePictureBloC>();
-
+class _SafeProfilePicturePageState
+    extends ModularState<SafeProfilePicturePage, SafeProfilePictureBloC> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   late String userAvatarPath;
 
@@ -48,36 +47,32 @@ class _SafeProfilePicturePageState extends State<SafeProfilePicturePage> {
         padding: const EdgeInsets.symmetric(horizontal: 30.0),
         child: Stack(
           children: [
-            _mountPhotosGridView(),
+            GridView.builder(
+              shrinkWrap: true,
+              padding: const EdgeInsets.only(bottom: 100),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                crossAxisSpacing: 30,
+                mainAxisSpacing: 10,
+              ),
+              itemCount: controller.listProfilePicturePaths.length,
+              itemBuilder: (context, index) {
+                var avatarPaths = controller.listProfilePicturePaths;
+                return SafeProfileAvatar(
+                  image: avatarPaths[index],
+                  isSelected: userAvatarPath == avatarPaths[index],
+                  type: ProfileAvatarType.animated,
+                  onTap: () => setState(() {
+                    userAvatarPath = avatarPaths[index];
+                    controller.setProfitePicture(userAvatarPath);
+                  }),
+                );
+              },
+            ),
             _mountButtons(),
           ],
         ),
       ),
-    );
-  }
-
-  Widget _mountPhotosGridView() {
-    return GridView.builder(
-      shrinkWrap: true,
-      padding: const EdgeInsets.only(bottom: 100),
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 3,
-        crossAxisSpacing: 30,
-        mainAxisSpacing: 10,
-      ),
-      itemCount: controller.listProfilePicturePaths.length,
-      itemBuilder: (context, index) {
-        var avatarPaths = controller.listProfilePicturePaths;
-        return SafeProfileAvatar(
-          image: avatarPaths[index],
-          isSelected: userAvatarPath == avatarPaths[index],
-          type: ProfileAvatarType.animated,
-          onTap: () => setState(() {
-            userAvatarPath = avatarPaths[index];
-            controller.setProfitePicture(userAvatarPath);
-          }),
-        );
-      },
     );
   }
 

--- a/lib/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart
+++ b/lib/src/components/widgets/safe_profile_picture/safe_profile_picture_page.dart
@@ -1,25 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:is_it_safe_app/generated/l10n.dart';
-import 'package:is_it_safe_app/src/app/modules/auth/register/presenter/bloc/register_bloc.dart';
 import 'package:is_it_safe_app/src/components/style/colors/safe_colors.dart';
 import 'package:is_it_safe_app/src/components/widgets/safe_app_bar.dart';
 import 'package:is_it_safe_app/src/components/widgets/safe_button.dart';
 import 'package:is_it_safe_app/src/components/widgets/safe_profile_avatar.dart';
+import 'package:is_it_safe_app/src/components/widgets/safe_profile_picture/bloc/safe_profile_picture_bloc.dart';
 import 'package:is_it_safe_app/src/components/widgets/safe_snack_bar.dart';
 import 'package:is_it_safe_app/src/core/util/safe_log_util.dart';
 
-class RegisterProfilePicturePage extends StatefulWidget {
+class SafeProfilePicturePage extends StatefulWidget {
   static const route = '/profile-picture';
-  const RegisterProfilePicturePage({Key? key}) : super(key: key);
+  const SafeProfilePicturePage({Key? key}) : super(key: key);
 
   @override
-  State<RegisterProfilePicturePage> createState() =>
-      _RegisterProfilePicturePageState();
+  State<SafeProfilePicturePage> createState() => _SafeProfilePicturePageState();
 }
 
-class _RegisterProfilePicturePageState
-    extends ModularState<RegisterProfilePicturePage, RegisterBloc> {
+class _SafeProfilePicturePageState extends State<SafeProfilePicturePage> {
+  final controller = Modular.get<SafeProfilePictureBloC>();
+
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   late String userAvatarPath;
 

--- a/lib/src/domain/use_case/update_user_use_case.dart
+++ b/lib/src/domain/use_case/update_user_use_case.dart
@@ -13,8 +13,8 @@ class UpdateUserUseCase extends SafeUseCase {
   }
 
   Future<UserEntity> call(RequestUpdateUser request) async {
-    final _response = await _service.updateUser(request);
+    final response = await _service.updateUser(request);
 
-    return UserEntity.toEntityUpdate(_response);
+    return UserEntity.toEntityUpdate(response);
   }
 }

--- a/lib/src/service/api/modules/profile/profile_service.dart
+++ b/lib/src/service/api/modules/profile/profile_service.dart
@@ -65,7 +65,7 @@ class ProfileService implements IProfileService {
     final requestConfig = RequestConfig(
       path: '${ApiConstants.updateUser}/${request.id}',
       method: HttpMethod.put,
-      body: request.toJson(request),
+      body: request.toJson(),
       options: Options(
         headers: {
           ApiConstants.kAuthorization: token,

--- a/lib/src/service/api/modules/profile/profile_service.dart
+++ b/lib/src/service/api/modules/profile/profile_service.dart
@@ -65,6 +65,7 @@ class ProfileService implements IProfileService {
     final requestConfig = RequestConfig(
       path: '${ApiConstants.updateUser}/${request.id}',
       method: HttpMethod.put,
+      body: request.toJson(request),
       options: Options(
         headers: {
           ApiConstants.kAuthorization: token,

--- a/lib/src/service/api/modules/profile/request/resquest_update_user.dart
+++ b/lib/src/service/api/modules/profile/request/resquest_update_user.dart
@@ -1,11 +1,11 @@
 class RequestUpdateUser {
-  int? id;
-  String? name;
-  String? nickname;
-  String? pronoun;
-  int? genderId;
-  int? sexualOrientationId;
-  String? profilePhoto;
+  final int? id;
+  final String? name;
+  final String? nickname;
+  final String? pronoun;
+  final int? genderId;
+  final int? sexualOrientationId;
+  final String? profilePhoto;
 
   RequestUpdateUser({
     this.id,


### PR DESCRIPTION
fix: SafeProfilePicturePage teve ModularState removido e adição do Modular.get() para pegar instância do `SafeProfilePicturBloC`.
MOTIVO: O ModularState, por padrão, tem um *auto dispose*, por isso ao atualizar o avatar do perfil e fechar a tela, esse auto dispose era chamado + o dispose do SafeBloC. Dessa forma, utilizar o Modular.get() é a melhor opção visto que não há chamada de um auto dispose do Modular, apenas do SafeBloC.