### PR TITLE
Feature/locais-proximos

### DIFF
--- a/lib/src/app/app_module.dart
+++ b/lib/src/app/app_module.dart
@@ -36,6 +36,6 @@ class AppModule extends Module {
     ModuleRoute(NavigationPage.route, module: NavigationModule()),
     ModuleRoute(ConfigurationModule.route, module: ConfigurationModule()),
     ModuleRoute(ReviewPage.route, module: ReviewModule()),
-    ModuleRoute(SaveLocationPage.route, module: LocationModule()),
+    ModuleRoute(LocationModule.route, module: LocationModule()),
   ];
 }

--- a/lib/src/app/modules/home/presenter/bloc/home_bloc.dart
+++ b/lib/src/app/modules/home/presenter/bloc/home_bloc.dart
@@ -131,6 +131,7 @@ class HomeBloc extends SafeBloC {
         }
       });
     });
+    print(userLocation);
     if (userLocation != null) {
       await saveUserLocation(userLocation: userLocation);
       userLocationController.sink.add(SafeEvent.done(userLocation));
@@ -157,14 +158,16 @@ class HomeBloc extends SafeBloC {
   }
 
   Future<bool> requestPermissionAndShowNearLocations() async {
-    saveUserLocationPermission(true);
     bool granted = false;
     await getCurrentLocation();
-    await Future.doWhile(() async {
-      return !(await verifyLocationPermission());
-    });
-    granted = true;
-    return granted;
+    if (!(await getUserLocationPermission())) {
+      saveUserLocationPermission(true);
+      await Future.doWhile(() async {
+        granted = !(await verifyLocationPermission());
+        return granted;
+      });
+    }
+    return !granted;
   }
 
   @override

--- a/lib/src/app/modules/home/presenter/pages/home_page.dart
+++ b/lib/src/app/modules/home/presenter/pages/home_page.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_print, deprecated_member_use
-
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:is_it_safe_app/generated/l10n.dart';

--- a/lib/src/app/modules/home/presenter/pages/home_page.dart
+++ b/lib/src/app/modules/home/presenter/pages/home_page.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_print, deprecated_member_use
+
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:is_it_safe_app/generated/l10n.dart';
@@ -24,10 +26,14 @@ class _HomePageState extends ModularState<HomePage, HomeBloc> {
   @override
   void initState() {
     WidgetsBinding.instance.waitUntilFirstFrameRasterized.then((_) async {
-      await controller.requestPermissionAndShowNearLocations().then((granted) {
-        controller.getLocationsNearUser();
-      }).timeout(const Duration(milliseconds: 400), onTimeout: () {
-        controller.getLocationsNearUser();
+      await controller
+          .requestPermissionAndShowNearLocations()
+          .then((granted) async {
+        if (granted) {
+          await controller.getLocationsNearUser();
+        }
+      }).timeout(const Duration(milliseconds: 400), onTimeout: () async {
+        await controller.getLocationsNearUser();
       });
     });
     super.initState();
@@ -49,8 +55,6 @@ class _HomePageState extends ModularState<HomePage, HomeBloc> {
                   .requestPermissionAndShowNearLocations()
                   .then((granted) {
                 controller.getLocationsNearUser();
-              }).timeout(const Duration(milliseconds: 400), onTimeout: () {
-                controller.getLocationsNearUser();
               });
             }
             if (tab == 1) {
@@ -70,6 +74,7 @@ class _HomePageState extends ModularState<HomePage, HomeBloc> {
                 buttonText: "Abrir configurações",
                 onTapButton: () async {
                   await controller.locator.requestPermission();
+                  await controller.getLocationsNearUser();
                 },
               ),
             ),

--- a/lib/src/app/modules/home/presenter/widgets/home_location_card.dart
+++ b/lib/src/app/modules/home/presenter/widgets/home_location_card.dart
@@ -28,16 +28,16 @@ class HomeLocationCard extends StatelessWidget {
         width: size.width,
         decoration: BoxDecoration(
           color: SafeColors.generalColors.primary,
-          borderRadius: BorderRadius.circular(8.0),
+          borderRadius: BorderRadius.circular(8),
         ),
         child: LayoutBuilder(builder: (context, constraints) {
           return Stack(
             children: [
               Column(
                 children: [
-                  _LocationPicture(location: location),
+                  _LocationPicture(location: location, size: size),
                   SizedBox(
-                    height: location.imagePath?.isNotEmpty == true ? 0.0 : 16.0,
+                    height: location.imagePath?.isNotEmpty == true ? 0 : 16,
                   ),
                   _LocationBody(location: location, size: size),
                 ],
@@ -57,20 +57,22 @@ class HomeLocationCard extends StatelessWidget {
 
 class _LocationPicture extends StatelessWidget {
   final LocationEntity location;
-  const _LocationPicture({Key? key, required this.location}) : super(key: key);
+  final Size size;
+  const _LocationPicture({Key? key, required this.location, required this.size})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     if (location.imagePath?.isNotEmpty == true) {
       return Container(
-        margin: const EdgeInsets.all(16.0),
-        height: 140,
+        margin: const EdgeInsets.all(16),
         width: MediaQuery.of(context).size.width,
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(8.0),
+          borderRadius: BorderRadius.circular(8),
         ),
         child: Image.network(
           location.imagePath!,
+          height: size.height * .15,
           fit: BoxFit.fitWidth,
           errorBuilder: (context, object, stackTrace) {
             return Image.asset(
@@ -119,7 +121,7 @@ class _LocationBody extends StatelessWidget {
 
   Widget _mountName(BuildContext context) {
     return SizedBox(
-      width: MediaQuery.of(context).size.width * 0.60,
+      width: MediaQuery.of(context).size.width * .6,
       child: Text(
         location.name,
         textAlign: TextAlign.start,
@@ -133,7 +135,7 @@ class _LocationBody extends StatelessWidget {
 
   Widget _moundAddress(BuildContext context) {
     return SizedBox(
-      width: MediaQuery.of(context).size.width * 0.65,
+      width: MediaQuery.of(context).size.width * .65,
       child: Text(
         location.address,
         maxLines: 2,

--- a/lib/src/app/modules/home/presenter/widgets/home_location_card.dart
+++ b/lib/src/app/modules/home/presenter/widgets/home_location_card.dart
@@ -23,7 +23,7 @@ class HomeLocationCard extends StatelessWidget {
     final size = MediaQuery.of(context).size;
 
     return GestureDetector(
-      onTap: onTap,
+      onTap: onTap as void Function(),
       child: Container(
         width: size.width,
         decoration: BoxDecoration(

--- a/lib/src/app/modules/home/presenter/widgets/home_location_card.dart
+++ b/lib/src/app/modules/home/presenter/widgets/home_location_card.dart
@@ -20,28 +20,47 @@ class HomeLocationCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        width: MediaQuery.of(context).size.width,
+        width: size.width,
         decoration: BoxDecoration(
           color: SafeColors.generalColors.primary,
           borderRadius: BorderRadius.circular(8.0),
         ),
-        child: Column(
-          children: [
-            _mountLocationPicture(context),
-            SizedBox(
-              height: location.imagePath?.isNotEmpty == true ? 0.0 : 16.0,
-            ),
-            _mountBody(context),
-          ],
-        ),
+        child: LayoutBuilder(builder: (context, constraints) {
+          return Stack(
+            children: [
+              Column(
+                children: [
+                  _LocationPicture(location: location),
+                  SizedBox(
+                    height: location.imagePath?.isNotEmpty == true ? 0.0 : 16.0,
+                  ),
+                  _LocationBody(location: location, size: size),
+                ],
+              ),
+              Positioned(
+                left: constraints.maxWidth * .058,
+                bottom: size.height * .073,
+                child: _LocationGrade(location: location),
+              ),
+            ],
+          );
+        }),
       ),
     );
   }
+}
 
-  Widget _mountLocationPicture(BuildContext context) {
+class _LocationPicture extends StatelessWidget {
+  final LocationEntity location;
+  const _LocationPicture({Key? key, required this.location}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
     if (location.imagePath?.isNotEmpty == true) {
       return Container(
         margin: const EdgeInsets.all(16.0),
@@ -65,14 +84,21 @@ class HomeLocationCard extends StatelessWidget {
       return const SizedBox.shrink();
     }
   }
+}
 
-  Widget _mountBody(BuildContext context) {
+class _LocationBody extends StatelessWidget {
+  final LocationEntity location;
+  final Size size;
+  const _LocationBody({Key? key, required this.location, required this.size})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _mountGrade(),
-        const SizedBox(width: 16),
+        const Spacer(),
         Column(
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.start,
@@ -86,23 +112,7 @@ class HomeLocationCard extends StatelessWidget {
             const SizedBox(height: 8),
           ],
         ),
-      ],
-    );
-  }
-
-  Widget _mountGrade() {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SvgPicture.asset(
-          AssetConstants.icons.star,
-          height: 35,
-          width: 35,
-        ),
-        Text(
-          location.averageGrade.toString(),
-          style: TextStyles.headline3(),
-        ),
+        SizedBox(width: size.width * .08),
       ],
     );
   }
@@ -143,6 +153,29 @@ class HomeLocationCard extends StatelessWidget {
               StringConstants.space +
               S.current.textReviews,
           style: TextStyles.helper(color: SafeColors.textColors.dark),
+        ),
+      ],
+    );
+  }
+}
+
+class _LocationGrade extends StatelessWidget {
+  final LocationEntity location;
+  const _LocationGrade({Key? key, required this.location}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SvgPicture.asset(
+          AssetConstants.icons.star,
+          height: 35,
+          width: 35,
+        ),
+        Text(
+          location.averageGrade.toString(),
+          style: TextStyles.headline3(),
         ),
       ],
     );

--- a/lib/src/app/modules/home/presenter/widgets/mount_getted_places.dart
+++ b/lib/src/app/modules/home/presenter/widgets/mount_getted_places.dart
@@ -55,10 +55,12 @@ class _SepararedList extends StatelessWidget {
       separatorBuilder: (_, i) => const SizedBox(height: 15),
       itemBuilder: (context, index) => HomeLocationCard(
         location: list[index],
-        onTap: () => Modular.to.pushNamed(
-          LocationModule.route + LocationPage.route,
-          arguments: list[index],
-        ),
+        onTap: () async {
+          await Modular.to.pushNamed(
+            LocationModule.route + LocationPage.route,
+            arguments: list[index],
+          );
+        },
       ),
     );
   }

--- a/lib/src/app/modules/location/location_module.dart
+++ b/lib/src/app/modules/location/location_module.dart
@@ -33,7 +33,7 @@ class LocationModule extends Module {
 
   @override
   final List<ModularRoute> routes = [
-    ChildRoute('/location-page',
+    ChildRoute(LocationPage.route,
         child: (_, args) =>
             LocationPage(location: (args.data as LocationEntity))),
     ModuleRoute(ReviewPage.route, module: ReviewModule()),

--- a/lib/src/components/location/safe_locator.dart
+++ b/lib/src/components/location/safe_locator.dart
@@ -64,7 +64,7 @@ class SafeLocator implements ISafeLocator {
   }
 
   @override
-  Future<void> requestPermission() => Geolocator.openLocationSettings();
+  Future<bool> requestPermission() => Geolocator.openLocationSettings();
 
   @override
   Future<bool> verifyPermission({Function? onLocationDenied}) async {

--- a/lib/src/core/interfaces/safe_locator.dart
+++ b/lib/src/core/interfaces/safe_locator.dart
@@ -5,7 +5,7 @@ abstract class ISafeLocator {
   Future<List<Placemark>?> getLocationList({Function? onLocationDenied});
   Future<Placemark?> getLocation({Function? onLocationDenied});
   Future<bool> verifyPermission({Function? onLocationDenied});
-  Future<void> requestPermission();
+  Future<bool> requestPermission();
   Future<Stream<Position>> getLocationStream({Duration? timeLimit});
   Future<void> getLastKnownPosition({Function? onLocationDenied});
 }


### PR DESCRIPTION
fix: Fluxo e comportamento da permissão de acesso à localização do usuário.
- Ao entrar no App pela primeira vez, o usuário é direcionado para a tela de permissões de localização do seu dispositivo.
- Ao permitir acesso à localização, o método `getLocationsNearUser()` é executado e os locais próximos ao usuário são carregados.
- Ao negar acesso à localização, será ativado um `onError`, exibindo uma tela com o alerta de que o usuário precisa permitir o acesso à localização para exibir os locais próximos, terá um botão abaixo para abrir as configurações de permissões novamente.

fix: Rota principal do `LocationModule`

fix: Design do `HomeLocationCard` agora atende ao modelo disposto no Figma