### PR TITLE
feat: [Profile] #134 - corrigindo edição para perfil.

### DIFF
--- a/lib/src/app/modules/configuration/account/presenter/bloc/edit_account_bloc.dart
+++ b/lib/src/app/modules/configuration/account/presenter/bloc/edit_account_bloc.dart
@@ -75,6 +75,11 @@ class EditAccountBloc extends SafeBloC {
     genderController = TextEditingController();
     userIdController = TextEditingController();
     pronounController = TextEditingController();
+
+    await getUser().whenComplete(() {
+      getGenders();
+      getSexualOrientations();
+    });
   }
 
   Future<bool> updateUser({required int userId}) async {
@@ -118,6 +123,19 @@ class EditAccountBloc extends SafeBloC {
       genderController.text = responseGetUSer.genreId.toString();
       sexualOrientationController.text =
           responseGetUSer.sexualOrientationId.toString();
+      if (responseGetUSer.genreId == null ||
+          responseGetUSer.sexualOrientationId == null) {
+        await Future.microtask(
+          () {
+            loadGenderFromList(
+              currentGender: responseGetUSer.gender ?? '',
+            );
+            loadSexualOrientationFromList(
+              currentSexualOrientation: responseGetUSer.orientation ?? '',
+            );
+          },
+        );
+      }
       userController.sink.add(SafeEvent.done(responseGetUSer));
     } on Exception catch (e) {
       userController.addError(e.toString());
@@ -188,4 +206,32 @@ class EditAccountBloc extends SafeBloC {
 
   @override
   Future<void> dispose() async {}
+
+  Future<void> loadGenderFromList({
+    required String currentGender,
+  }) async {
+    getGendersUseCase.call().fold(
+      (success) {
+        GenderEntity selectedGender = success.firstWhere(
+          (element) => element.title == currentGender,
+        );
+        genderController.text = selectedGender.id.toString();
+      },
+      (error) {},
+    );
+  }
+
+  Future<void> loadSexualOrientationFromList({
+    required String currentSexualOrientation,
+  }) async {
+    getSexualOrientationsUseCase.call().fold(
+      (success) {
+        SexualOrientationEntity selectedSexualOrientation = success.firstWhere(
+          (element) => element.title == currentSexualOrientation,
+        );
+        sexualOrientationController.text = selectedSexualOrientation.id.toString();
+      },
+      (error) {},
+    );
+  }
 }

--- a/lib/src/app/modules/configuration/account/presenter/pages/edit_account_page.dart
+++ b/lib/src/app/modules/configuration/account/presenter/pages/edit_account_page.dart
@@ -64,9 +64,10 @@ class _EditAccountPageState
                 ),
                 const SizedBox(height: 16),
                 GenderEditAcount(
-                    controller: controller.gendersController,
-                    genderController: controller.genderController,
-                    isGenderDropdownExpanded: isGenderDropdownExpanded),
+                  controller: controller.gendersController,
+                  genderController: controller.genderController,
+                  isGenderDropdownExpanded: isGenderDropdownExpanded,
+                ),
                 const SizedBox(height: 24),
                 _mountUpdateUserButton(),
                 const SizedBox(height: 20),
@@ -329,8 +330,5 @@ class _EditAccountPageState
   void initState() {
     super.initState();
     SafeLogUtil.instance.route(Modular.to.path);
-    controller.getUser();
-    controller.getGenders();
-    controller.getSexualOrientations();
   }
 }

--- a/lib/src/components/widgets/safe_dropdown.dart
+++ b/lib/src/components/widgets/safe_dropdown.dart
@@ -22,6 +22,17 @@ class SafeDropDown extends StatefulWidget {
 
 class _SafeDropDownState extends State<SafeDropDown> {
   @override
+  void initState() {
+    if (int.tryParse(widget.controller.text) != null) {
+      dynamic foundValue = widget.values.firstWhere(
+        (element) => element.id == int.parse(widget.controller.text),
+      );
+      widget.title = foundValue.title;
+    }
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(


### PR DESCRIPTION
Alterações feitas com o objetivo de resolver o bug mencionado na tarefa [Mobile 134](https://github.com/Is-It-Safe/mobile/issues/134)

Descrição: Não é possível salvar apenas as atualizações de nome/usuário/pronome sem precisar selecionar Orientação Sexual e Gênero.

Motivo: As informações relacionadas a orientação sexual e gênero do usuário não são carregadas portanto o input do usuário é necessário.

 Passos para reproduzir:

- Abrir drawer via página home da aplicação;
- Navegar a página de perfil do usuário
- Navegar para página de edição de perfil
- Esperar carregamento dos dados
- Observar campos de seleção para gênero e orientação sexual

Evidencia:
[device-2023-03-15-175758.webm](https://user-images.githubusercontent.com/28909884/225440777-9278fc0f-6a22-4ef2-accd-96521e3d6354.webm)
