### PR TITLE
[Fix-211] Ajustando validação para campo de pronomes.

### DIFF
--- a/lib/src/app/modules/auth/modules/register/presenter/vo/register_user_vo.dart
+++ b/lib/src/app/modules/auth/modules/register/presenter/vo/register_user_vo.dart
@@ -11,7 +11,11 @@ class RegisterUserVo {
 
   RegisterUserVo({
     required this.userSignInEnum,
-  });
+  }) {
+    if (this.userSignInEnum == UserSignInEnum.pronouns) {
+      isValid = true;
+    }
+  }
 
   String? validateUserData({
     String? currentPassword,


### PR DESCRIPTION
Alterações feitas com o objetivo de resolver o bug mencionado na tarefa [211](https://github.com/Is-It-Safe/mobile/issues/211)

Descrição: Na tela de "Cadastro" o campo "Pronomes" não é exibido como obrigatório (sem " * " e sem a caixa vermelha ao deixar vazio), no entanto não é possível prosseguir o cadastro com campo "Pronomes" vazio.

Motivo: Ao inicializar a lista representando todos os itens utilizados durante o cadastro a entidade pronome acabava sendo iniciada com a validação falsa por padrão.

Passos para reproduzir:

- Abrir modulo de cadastro;
- Realizar passos de cadastro normalmente deixando campo de pronome em branco;
- Testar validação do botão "cadastrar";
- Navegar para próxima tela.

Evidencia:

[screencast-Genymotion-2023-04-22_12.32.47.376.webm](https://user-images.githubusercontent.com/28909884/233793439-516cd3f5-60c8-4dd9-9c5b-9acdf337615d.webm)
