### PR TITLE
[Fix-222] hotfix para falha de redirecionamento em botão em login

### DIFF
--- a/lib/src/app/modules/auth/modules/login/presenter/bloc/login_bloc.dart
+++ b/lib/src/app/modules/auth/modules/login/presenter/bloc/login_bloc.dart
@@ -170,7 +170,10 @@ class LoginBloc extends SafeBloC {
   }
 
   Future<void> forgotPassword() async {
-    final Uri url = Uri(path: ApiConstants.kForgotPassword);
+    final Uri url = Uri(
+      scheme: 'https',
+      path: ApiConstants.kForgotPassword,
+    );
     if (await canLaunchUrl(url)) {
       await launchUrl(url);
     }

--- a/lib/src/service/api/constants/api_constants.dart
+++ b/lib/src/service/api/constants/api_constants.dart
@@ -31,7 +31,7 @@ class ApiConstants {
 
   ///URL para direcionar usuario a pagina web de esqueceu a senha
   static const String kForgotPassword =
-      'https://is-it-safe-api-v2.herokuapp.com/is-it-safe/forgot';
+      'is-it-safe-api-v2.herokuapp.com/is-it-safe/forgot';
   /*--------------------------------------------------------------------*/
 
   //Auth

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
 
   #Testes
   mocktail: ^0.3.0
-  url_launcher: ^6.1.7
+  url_launcher: ^6.1.10
   result_dart: ^1.0.5
 
   #Monitoramento


### PR DESCRIPTION
Alterações feitas com o objetivo de resolver o bug mencionado na tarefa [222](https://github.com/Is-It-Safe/mobile/issues/222)

Descrição: Funcionalidade de Login "Esqueceu sua senha?" desabilitada.

Motivo: Na família 2.19.x do Dart o parser utilizado pela classe URI esta quebrado causando problemas em caracteres especiais, especificar o tipo de protocolo utilizado ajuda a resolver o problema enquanto o bug não é corrigido.

Obs: Vamos precisar ficar vigilantes com o uso desta classe.

Passos para reproduzir:

- Abrir modulo de login
- Tocar em botão "Esqueci minha senha"

Evidencia:

[screencast-Genymotion-2023-05-02_20.40.00.505.webm](https://user-images.githubusercontent.com/28909884/235807794-9e2f5efe-6fc7-4a1a-944f-fa1d3e9b0cfc.webm)
