### PR TITLE
fix: espaçamento após as vírgulas

### DIFF
--- a/lib/src/app/modules/location/presenter/pages/location_page.dart
+++ b/lib/src/app/modules/location/presenter/pages/location_page.dart
@@ -92,7 +92,7 @@ class _LocationPageState extends SafeState<LocationPage, LocationBloC> {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      location.address,
+                      location.address.split(',').join(', '),
                       overflow: TextOverflow.clip,
                       style: TextStyles.caption().copyWith(
                         fontWeight: FontWeight.w500,

--- a/lib/src/app/modules/search/presenter/widgets/search_location_card.dart
+++ b/lib/src/app/modules/search/presenter/widgets/search_location_card.dart
@@ -69,7 +69,7 @@ class SearchLocationCard extends StatelessWidget {
 
   Widget _mountLocationAddress(Size size) {
     return Text(
-      location.address,
+      location.address.split(',').join(', '),
       textAlign: TextAlign.left,
       softWrap: true,
       style: TextStyles.label(),


### PR DESCRIPTION
Colocado espaçamento entre as palavras, após as vírgulas

### O que foi feito? 

Acrescentei replaceAll()

<!-- Descreva a futura versão após o merge -->

Após o merge é para ter espaço após as vírgulas ao digitar endereço

### Tipo de Mudança:

<!-- Descomente a alternativa que contemple sua alteração-->

 [x] bug 
<!-- - [x] feature -->
<!-- - [x] test -->
<!-- - [x] docs -->
<!-- - [x] refactor-->



### Validações:

<!-- Ao menos um dos campos devem possuir marcações. -->

#### Testes Unitários:

- [ ] Meu código possui os devidos testes unitários

#### Layout:

- [ ] Não houveram mudanças nas telas
- [x
![address_1](https://github.com/Is-It-Safe/mobile/assets/58519231/6ab47072-8f89-468e-b8ac-e758bfcbff76)
![address_2](https://github.com/Is-It-Safe/mobile/assets/58519231/5a9414c5-0e44-44e7-a2e6-a20eaac4ae5d)
] Necessita de validação de Design

### Screenshots

<!-- Caso seja necessário, linke aqui prints/GIFs ou vídeos da solução -->
