### PR TITLE
[FIX]: Fixing url_launcher launch mode.

### DIFF
--- a/lib/src/app/modules/auth/modules/login/presenter/bloc/login_bloc.dart
+++ b/lib/src/app/modules/auth/modules/login/presenter/bloc/login_bloc.dart
@@ -172,19 +172,18 @@ class LoginBloc extends SafeBloC {
 
   Future<void> forgotPassword() async {
     final Uri url = Uri(
-      scheme: ApiConstants.ignoreSSLCertificate
-          ? StringConstants.http
-          : StringConstants.https,
+      scheme: StringConstants.https,
       host: FlavorUtil.instance.url.replaceAll(
-        ApiConstants.ignoreSSLCertificate
-            ? StringConstants.httpComplete
-            : StringConstants.httpsComplete,
+        StringConstants.httpsComplete,
         StringConstants.empty,
       ),
       path: ApiConstants.kForgotPassword,
     );
     if (await canLaunchUrl(url)) {
-      await launchUrl(url);
+      await launchUrl(
+        url,
+        mode: LaunchMode.externalApplication,
+      );
     }
   }
 

--- a/lib/src/service/api/constants/api_constants.dart
+++ b/lib/src/service/api/constants/api_constants.dart
@@ -34,7 +34,7 @@ class ApiConstants {
   static const String kUrlCep = 'viacep.com.br/ws/cep/json/';
 
   ///URL para direcionar usuario a pagina web de esqueceu a senha
-  static String kForgotPassword = '/is-it-safe/forgot';
+  static String kForgotPassword = '/forgot';
 
   ///Variavel para definir se será ignorado, ou não, o certificado ssl
   static bool ignoreSSLCertificate = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,8 +53,8 @@ dependencies:
   shared_preferences: ^2.0.15
 
   #Testes
-  mocktail: ^0.3.0
-  url_launcher: ^6.1.10
+  mocktail: ^1.0.0
+  url_launcher: ^6.1.14
   result_dart: ^1.0.5
 
   #Monitoramento


### PR DESCRIPTION
### O que foi feito? 

<!-- Descreva a futura versão após o merge -->

### Tipo de Mudança:

Basicamente este MR altera o modo em que URLS são abertas ao iniciar o fluxo "esqueceu minha senha". O bug ocorre devido a família 6 introduzir a opção de tipo de lançamento para navegadores que por padrão fica a ser definido pelo o sistema operacional.

Forçar o lançamento a ser externo resolveu o problema.

<!-- - [x] bug -->
<!-- - [] feature -->
<!-- - [] test -->
<!-- - [] docs -->
<!-- - [] refactor-->



### Validações:

<!-- Ao menos um dos campos devem possuir marcações. -->

#### Testes Unitários:

- [ ] Meu código possui os devidos testes unitários

#### Layout:

- [X] Não houveram mudanças nas telas
- [ ] Necessita de validação de Design