### PR TITLE
botão de cadastrar só habilita com os dados e termos aceitos

### DIFF
--- a/lib/src/app/modules/auth/modules/register/presenter/bloc/register_bloc.dart
+++ b/lib/src/app/modules/auth/modules/register/presenter/bloc/register_bloc.dart
@@ -43,11 +43,13 @@ class RegisterBloc extends SafeBloC {
 
   void toggleRegisterButton(RegisterBloc? bloc) {
     bool isPasswordNotEmpty = bloc!.passwordController.text.isNotEmpty;
-    bool isMatchPasswords = bloc.confirmPasswordController.text == bloc.passwordController.text;
+    bool isMatchPasswords =
+        bloc.confirmPasswordController.text == bloc.passwordController.text;
     bool isEnabled = !store.listRegisterTextFieldVO.any(
       (element) => element.isValid == false,
     );
-    store.isRegisterButtonEnabled.data = isEnabled && isPasswordNotEmpty && isMatchPasswords;
+    store.isRegisterButtonEnabled.data =
+        isEnabled && isPasswordNotEmpty && isMatchPasswords;
   }
 
   void toggleTermsAndConditions() {
@@ -138,10 +140,18 @@ class RegisterBloc extends SafeBloC {
     if (await isUsernameAvailable() == false) return;
     if (await isEmailAvailable() == false) return;
 
-
     Modular.to.pushNamed(
       StringConstants.dot + RegisterProfilePage.route,
     );
+  }
+
+  bool enableButton() {
+    if (store.isRegisterButtonEnabled.data != false &&
+        store.isTermsAndConditionsChecked.data != false){
+      return true;
+    } else {
+      return false;
+    }
   }
 
   @override

--- a/lib/src/app/modules/auth/modules/register/presenter/pages/register_page.dart
+++ b/lib/src/app/modules/auth/modules/register/presenter/pages/register_page.dart
@@ -125,8 +125,11 @@ class _RegisterPageState extends SafeState<RegisterPage, RegisterBloc> {
                               bloc.store.isRegisterButtonEnabled,
                           isAcceptedTerms:
                               bloc.store.isTermsAndConditionsChecked,
-                          onTap: () async =>
-                              await bloc.navigateToRegisterProfile(),
+                          onTap: () async {
+                            if (bloc.store.isRegisterButtonEnabled.data == true && bloc.store.isTermsAndConditionsChecked.data == true) {
+                              await bloc.navigateToRegisterProfile();
+                            }
+                          },
                         );
                       },
                     ),

--- a/lib/src/app/modules/auth/modules/register/presenter/pages/register_page.dart
+++ b/lib/src/app/modules/auth/modules/register/presenter/pages/register_page.dart
@@ -126,8 +126,11 @@ class _RegisterPageState extends SafeState<RegisterPage, RegisterBloc> {
                           isAcceptedTerms:
                               bloc.store.isTermsAndConditionsChecked,
                           onTap: () async {
-                            if (bloc.store.isRegisterButtonEnabled.data == true && bloc.store.isTermsAndConditionsChecked.data == true) {
+                            bool isButtonEnabled = bloc.enableButton();
+                            if (isButtonEnabled) {
                               await bloc.navigateToRegisterProfile();
+                            } else {
+                             null;
                             }
                           },
                         );


### PR DESCRIPTION
### O que foi feito? 
Habilitado botão de CADASTRAR com dados preenchidos e aceite dos termos
<!-- Descreva a futura versão após o merge -->

### Tipo de Mudança:

Uploading aceite de termos.mov…



[x] bug



### Validações:

<!-- Ao menos um dos campos devem possuir marcações. -->

#### Testes Unitários:

- [ ] Meu código possui os devidos testes unitários

#### Layout:

- [ ] Não houveram mudanças nas telas
- [ ] Necessita de validação de Design

### Screenshots

<!-- Caso seja necessário, linke aqui prints/GIFs ou vídeos da solução -->
