### PR TITLE
[199] Exibir o nome do usuário atualizado depois da edição

### DIFF
--- a/lib/src/app/modules/configuration/account/modules/edit_account_module/edit_account_module.dart
+++ b/lib/src/app/modules/configuration/account/modules/edit_account_module/edit_account_module.dart
@@ -3,6 +3,7 @@ import 'package:is_it_safe_app/src/app/modules/auth/services/auth_service.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/domain/usecases/get_genders_use_case.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/domain/usecases/get_sexual_orientation_use_case.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/domain/usecases/save_user_login_use_case.dart';
+import 'package:is_it_safe_app/src/app/modules/configuration/account/domain/usecases/save_user_name_use_case.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/modules/edit_account_module/presenter/bloc/edit_account_bloc.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/modules/edit_account_module/presenter/pages/edit_account_page.dart';
 import 'package:is_it_safe_app/src/app/modules/profile/domain/usecases/get_user_use_case.dart';
@@ -32,6 +33,7 @@ class EditAccountModule extends Module {
           getGendersUseCase: i.get<GetGendersUseCase>(),
           getSexualOrientationsUseCase: i.get<GetSexualOrientationsUseCase>(),
           updateUserUseCase: i.get<UpdateUserUseCase>(),
+          saveUserNameUseCase: i.get<SaveUserNameUseCase>(),
         )),
   ];
 

--- a/lib/src/app/modules/configuration/account/presenter/bloc/account_bloc.dart
+++ b/lib/src/app/modules/configuration/account/presenter/bloc/account_bloc.dart
@@ -5,6 +5,8 @@ import 'package:is_it_safe_app/generated/l10n.dart';
 import 'package:is_it_safe_app/src/app/modules/auth/modules/login/presenter/pages/login_page.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/domain/usecases/save_user_image_use_case.dart';
 import 'package:is_it_safe_app/src/app/modules/configuration/account/domain/usecases/save_user_login_use_case.dart';
+import 'package:is_it_safe_app/src/app/modules/configuration/account/modules/edit_account_module/presenter/pages/edit_account_page.dart';
+import 'package:is_it_safe_app/src/app/modules/configuration/account/presenter/pages/account_page.dart';
 import 'package:is_it_safe_app/src/app/modules/profile/domain/models/request/resquest_update_user.dart';
 import 'package:is_it_safe_app/src/app/modules/profile/domain/usecases/get_user_use_case.dart';
 import 'package:is_it_safe_app/src/app/modules/profile/domain/usecases/update_user_use_case.dart';
@@ -99,6 +101,16 @@ class AccountBloc extends SafeBloC {
             (r) => false,
           ),
         );
+  }
+
+  void navigateToEditAccount() {
+    Modular.to
+        .pushNamed(StringConstants.dot + EditAccountPage.route)
+        .then((value) async {
+      EditAccountReturn result = value as EditAccountReturn;
+      if (result.isAccountChanged == false) return;
+      await getUser();
+    });
   }
 
   @override

--- a/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
+++ b/lib/src/app/modules/configuration/account/presenter/pages/account_page.dart
@@ -43,9 +43,7 @@ class _AccountPageState extends SafeState<AccountPage, AccountBloc> {
             const SizedBox(height: 20),
             AccountInfoButton(
               text: S.current.textEditProfile,
-              onTap: () => Modular.to.pushNamed(
-                '.${EditAccountPage.route}',
-              ),
+              onTap: () => bloc.navigateToEditAccount(),
             ),
             const SizedBox(height: 20),
             AccountSectionBanner(text: S.current.textAccountInformation),
@@ -86,4 +84,12 @@ class _AccountPageState extends SafeState<AccountPage, AccountBloc> {
       ),
     );
   }
+}
+
+class EditAccountReturn {
+  final bool isAccountChanged;
+
+  EditAccountReturn({
+    required this.isAccountChanged,
+  });
 }


### PR DESCRIPTION
### O que foi feito? 
Fix para exibir corretamente o nome do usuário no perfil e no drawer após a edição

### Tipo de Mudança:

<!-- Descomente a alternativa que contemple sua alteração-->

[x] bug
<!-- - [x] feature -->
<!-- - [x] test -->
<!-- - [x] docs -->
<!-- - [x] refactor-->

### Validações:

<!-- Ao menos um dos campos devem possuir marcações. -->

#### Testes Unitários:

- [ ] Meu código possui os devidos testes unitários

#### Layout:

- [x] Não houveram mudanças nas telas
- [ ] Necessita de validação de Design
