### PR TITLE
437 bug criação de conta com nome utilizando apenas espaços em branco

### DIFF
--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -220,10 +220,10 @@ class S {
     );
   }
 
-  /// `Esse campo não pode ficar vazio`
+  /// `Espaços vazios não são válidos`
   String get textErrorEmptyField {
     return Intl.message(
-      'Esse campo não pode ficar vazio',
+      'Espaços vazios não são válidos',
       name: 'textErrorEmptyField',
       desc: '',
       args: [],
@@ -1293,7 +1293,7 @@ class S {
   /// `Estamos processando os detalhes do estabelecimento para tornar sua experiência ainda mais incrível. Em breve, ele estará visível para todos!`
   String get textSuccessSaveLocation {
     return Intl.message(
-     'Estamos processando os detalhes do estabelecimento para tornar sua experiência ainda mais incrível. Em breve, ele estará visível para todos!',
+      'Estamos processando os detalhes do estabelecimento para tornar sua experiência ainda mais incrível. Em breve, ele estará visível para todos!',
       name: 'textSuccessSaveLocation',
       desc: '',
       args: [],

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -23,7 +23,7 @@
     "textErrorLoginPassword":"Por favor, digite uma senha válida",
     "textErrorWrongFields":"Campos errados! Tente novamente.",
     "textErrorInvalidDate":"Por favor, digite uma data válida",
-    "textErrorEmptyField":"Esse campo não pode ficar vazio",
+    "textErrorEmptyField":"Espaços vazios não são válidos",
     "textErrorUserName":"O nome do usuário precisa conter 4 caracteres ou mais",
     "textErrorEmail":"Por favor, digite um e-mail válido",
     "textErrorPronouns":"ex: Ela/Dela, Ele/Dele, Ela/Elu",

--- a/lib/src/app/modules/auth/modules/register/presenter/widgets/register_user_field.dart
+++ b/lib/src/app/modules/auth/modules/register/presenter/widgets/register_user_field.dart
@@ -30,6 +30,9 @@ class RegisterTextFormField extends StatelessWidget {
       bottomText: UserSignInUtil.getCorrectBottomTextForSignIn(
         userSignInEnum: registerTextFieldVO.userSignInEnum,
       ),
+      maxLength: UserSignInUtil.getCorrectMaxLengthForSignIn(
+        userSignInEnum: registerTextFieldVO.userSignInEnum,
+      ),
       onChanged: (_) => onChanged(),
       validator: (_) => onValidate(),
     );

--- a/lib/src/core/constants/regex_constants.dart
+++ b/lib/src/core/constants/regex_constants.dart
@@ -6,4 +6,6 @@ class RegexConstants {
       r'^(?=.*\d)(?=.*[\x21-\x2F\x3A-\x40\x5B-\x60\x7B-\x7E])[0-9a-zA-Z\x21-\x2F\x3A-\x40\x5B-\x60\x7B-\x7E]{8,}$';
   static const Pattern linkFromTextRegex =
       r'((https?:www\.)|(https?:\/\/)|(www\.))[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9]{1,6}(\/[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)?';
+  static const Pattern nameRegex =
+      r'^[a-zA-Z]+(?:\s[a-zA-Z]+)*$';
 }

--- a/lib/src/core/extentions/validation_extentions.dart
+++ b/lib/src/core/extentions/validation_extentions.dart
@@ -9,9 +9,7 @@ extension SafeValidation on String {
         RegExp(RegexConstants.passwordRegex as String),
       );
 
-  bool get isName {
-    return length > 3 && isNotEmpty;
-  }
+  bool get isName => contains(RegExp(RegexConstants.nameRegex as String));
 
   bool get isNickName {
     return length > 3 && isNotEmpty && !contains(" ");

--- a/lib/src/core/util/user_sign_in_util.dart
+++ b/lib/src/core/util/user_sign_in_util.dart
@@ -3,6 +3,21 @@ import 'package:is_it_safe_app/src/core/constants/string_constants.dart';
 import 'package:is_it_safe_app/src/core/enum/user_sign_in_enum.dart';
 
 class UserSignInUtil {
+  static int? getCorrectMaxLengthForSignIn({
+    required UserSignInEnum userSignInEnum,
+  }) {
+    switch (userSignInEnum) {
+      case UserSignInEnum.user:
+        return 50;
+      case UserSignInEnum.nickName:
+        return 15;
+      case UserSignInEnum.pronouns:
+        return null;
+      case UserSignInEnum.email:
+        return null;
+    }
+  }
+
   static String getCorrectLabelForSignIn({
     required UserSignInEnum userSignInEnum,
   }) {


### PR DESCRIPTION
### O que foi feito? 

<!-- Descreva a futura versão após o merge -->
1 - Foi criada uma nova regra impedindo que o usuário passasse pela validação de nome com apenas espaços em branco.
2 - Foi modificado a mensagem de erro caso ocorresse do usuário deixar um espaço em branco do no final do nome.
3 - Foi adicionado uma função para determinar o limite de caracteres nos campos de nome e nome de usuário.

### Tipo de Mudança:

<!-- Descomente a alternativa que contemple sua alteração-->

 [x] bug 
<!-- - [x] feature -->
<!-- - [x] test -->
<!-- - [x] docs -->
<!-- - [x] refactor-->



### Validações:

<!-- Ao menos um dos campos devem possuir marcações. -->

#### Testes Unitários:

- [ ] Meu código possui os devidos testes unitários

#### Layout:

- [ ] Não houveram mudanças nas telas
- [ ] Necessita de validação de Design

### Screenshots

<!-- Caso seja necessário, linke aqui prints/GIFs ou vídeos da solução -->
